### PR TITLE
CORE-2063 Force sign-out if Keycloak access token is expired

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -10,24 +10,27 @@ import { getServerSession, DefaultUser } from "next-auth";
 import KeycloakProvider from "next-auth/providers/keycloak";
 
 declare module "next-auth" {
-    // Extend the Session type to include accessToken and username
+    // Extend the Session type to include accessToken, accessTokenExp, and username.
     interface Session {
         accessToken?: string | null;
+        accessTokenExp?: number | null;
         user?: {
             username?: string | null;
         } & DefaultUser;
     }
 
-    // Extend the Profile type to include username
+    // Extend the Profile type to include username and exp.
     interface Profile {
+        exp?: number | null;
         preferred_username?: string | null;
     }
 }
 
 declare module "next-auth/jwt" {
-    // Extend the JWT type to include accessToken and username
+    // Extend the JWT type to include accessToken, username, and accessTokenExp.
     interface JWT {
         accessToken?: string | null;
+        accessTokenExp?: number | null;
         username?: string | null;
     }
 }
@@ -52,6 +55,7 @@ export const config = {
             // Persist the OAuth access_token and the username in the token right after signin.
             if (profile) {
                 token.accessToken = account?.access_token;
+                token.accessTokenExp = profile.exp;
                 token.username = profile.preferred_username;
             }
 
@@ -60,6 +64,7 @@ export const config = {
         async session({ session, token }) {
             // Send properties to the client, like the accessToken and username from the provider.
             session.accessToken = token.accessToken;
+            session.accessTokenExp = token.accessTokenExp;
             if (session.user) {
                 session.user.username = token.username;
             }

--- a/src/components/AccountAvatar.tsx
+++ b/src/components/AccountAvatar.tsx
@@ -26,6 +26,15 @@ const AccountAvatar = () => {
 
     const userFirstInitial = session?.user?.name?.charAt(0).toUpperCase();
 
+    React.useEffect(() => {
+        if (session?.accessTokenExp) {
+            // If the access token has expired, force a sign out for now.
+            if (new Date(session.accessTokenExp * 1000) < new Date()) {
+                signOut();
+            }
+        }
+    }, [session]);
+
     const handleUserAvatarClick = (event: React.MouseEvent<HTMLDivElement>) => {
         if (!session) {
             signIn("keycloak");


### PR DESCRIPTION
The `next-auth` session and jwt `exp` values are 30 days longer than the Keycloak access token's `exp` value, so after the access token expires, the session has not expired and the user still appears to be logged in, but calling a terrain endpoint with that token will return a 403 error.

So this adds another `accessTokenExp` field to the `session` object that can be checked in a `useEffect` in the `AccountAvatar`, which can call the `signOut` function if the token is expired.