### PR TITLE
CORE-2083 Add /api/healthz endpoint

### DIFF
--- a/src/app/api/healthz/route.ts
+++ b/src/app/api/healthz/route.ts
@@ -1,0 +1,19 @@
+import { healthCheck } from "@/db";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    let databaseOK = false;
+    let status = 500;
+
+    try {
+        const current_version = await healthCheck();
+        if (current_version) {
+            databaseOK = true;
+            status = 200;
+        }
+    } catch (e) {
+        console.error("Database error", e);
+    }
+
+    return NextResponse.json({ databaseOK }, { status });
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -83,6 +83,14 @@ type TransactionResponse = {
     network_transaction_id?: string | null;
 };
 
+export async function healthCheck() {
+    const { rows } = await db.query(
+        "SELECT max(version) as current_version FROM schema_migrations WHERE dirty = false",
+    );
+
+    return rows ? rows[0]?.current_version : null;
+}
+
 /**
  * Adds the `transaction` to the database as a purchase order,
  * returning the `po_number`.


### PR DESCRIPTION
This PR will add an `/api/healthz` endpoint that returns 200 if the database can be queried.

This can be used by k8s to check the pod's health, and if the service loses connection with the db, it can be restarted by k8s.