### PR TITLE
CORE-2068 Add-ons support

### DIFF
--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -20,7 +20,7 @@ import {
 import { addonProratedRate } from "@/utils/rates";
 import { OrderRequestSchema } from "@/validation";
 
-import { addDays, toDate } from "date-fns";
+import { differenceInCalendarDays } from "date-fns";
 import { UUID } from "crypto";
 import getConfig from "next/config";
 import { NextRequest, NextResponse } from "next/server";
@@ -155,7 +155,7 @@ export async function POST(request: NextRequest) {
         // Validate the user's subscription end date.
         if (
             !subscriptionEndDate ||
-            toDate(subscriptionEndDate) > addDays(new Date(), 30)
+            differenceInCalendarDays(subscriptionEndDate, new Date()) > 30
         ) {
             return NextResponse.json(
                 {

--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/auth";
 import { addPurchaseRecord, addTransactionResponse } from "@/db";
 import {
     CreateTransactionResponse,
+    LineItemIDEnum,
     OrderError,
     OrderRequest,
     OrderUpdateResult,
@@ -97,25 +98,17 @@ export async function POST(request: NextRequest) {
             amount,
             currencyCode,
             payment: { creditCard: { cardNumber, expirationDate, cardCode } },
-            lineItems: lineItems?.map(
-                ({
-                    lineItem: {
+            lineItems: {
+                lineItem: lineItems?.lineItem?.map(
+                    ({ itemId, name, description, quantity, unitPrice }) => ({
                         itemId,
                         name,
                         description,
                         quantity,
                         unitPrice,
-                    },
-                }) => ({
-                    lineItem: {
-                        itemId,
-                        name,
-                        description,
-                        quantity,
-                        unitPrice,
-                    },
-                }),
-            ),
+                    }),
+                ),
+            },
             poNumber: 0, // placeholder
             billTo: { firstName, lastName, company, address, city, state, zip },
             customerIP,
@@ -124,9 +117,9 @@ export async function POST(request: NextRequest) {
 
     const currentPricing: OrderError["currentPricing"] = { amount: 0 };
 
-    const subscription = lineItems?.find(
-        (item) => item.lineItem.itemId === "subscription",
-    )?.lineItem;
+    const subscription = lineItems?.lineItem?.find(
+        (item) => item.itemId === LineItemIDEnum.SUBSCRIPTION,
+    );
 
     let currentSubscription: SubscriptionSummaryDetails | undefined;
     let orderSubscription: PlanType | undefined;

--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -114,6 +114,7 @@ export async function POST(request: NextRequest) {
                 ),
             },
             poNumber: 0, // placeholder
+            customer: { email: session.user?.email },
             billTo: { firstName, lastName, company, address, city, state, zip },
             customerIP,
         } as TransactionRequest,

--- a/src/app/api/serviceFacade.ts
+++ b/src/app/api/serviceFacade.ts
@@ -71,6 +71,15 @@ export function getPlanTypes() {
 export const PLAN_TYPES_QUERY_KEY = "fetchPlanTypes";
 
 /**
+ * Fetch subscription add-ons.
+ */
+export function getAddons() {
+    return get("/api/subscriptions/addons");
+}
+
+export const ADDONS_QUERY_KEY = "fetchAddons";
+
+/**
  * Place a purchase order.
  */
 export function postOrder(order: OrderRequest) {

--- a/src/app/api/subscriptions/addons/route.ts
+++ b/src/app/api/subscriptions/addons/route.ts
@@ -1,40 +1,5 @@
-import {
-    getServiceAccountToken,
-    terrainErrorResponse,
-} from "@/app/api/terrain";
-
-import getConfig from "next/config";
-import { NextResponse } from "next/server";
-
-const { publicRuntimeConfig } = getConfig();
+import { serviceAccountFetchAddons } from "@/app/api/terrain";
 
 export async function GET() {
-    const { terrainBaseUrl } = publicRuntimeConfig;
-
-    const token = await getServiceAccountToken();
-    if (!token) {
-        return NextResponse.json(
-            { message: "Could not get service account token." },
-            {
-                status: 500,
-            },
-        );
-    }
-
-    const url = "/service/qms/addons";
-
-    const response = await fetch(`${terrainBaseUrl}${url}`, {
-        method: "GET",
-        headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-        },
-    });
-
-    if (!response.ok) {
-        return terrainErrorResponse(url, response);
-    }
-
-    const data = await response.json();
-    return NextResponse.json(data);
+    return serviceAccountFetchAddons();
 }

--- a/src/app/api/subscriptions/addons/route.ts
+++ b/src/app/api/subscriptions/addons/route.ts
@@ -1,0 +1,40 @@
+import {
+    getServiceAccountToken,
+    terrainErrorResponse,
+} from "@/app/api/terrain";
+
+import getConfig from "next/config";
+import { NextResponse } from "next/server";
+
+const { publicRuntimeConfig } = getConfig();
+
+export async function GET() {
+    const { terrainBaseUrl } = publicRuntimeConfig;
+
+    const token = await getServiceAccountToken();
+    if (!token) {
+        return NextResponse.json(
+            { message: "Could not get service account token." },
+            {
+                status: 500,
+            },
+        );
+    }
+
+    const url = "/service/qms/addons";
+
+    const response = await fetch(`${terrainBaseUrl}${url}`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    if (!response.ok) {
+        return terrainErrorResponse(url, response);
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+}

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -75,7 +75,7 @@ export async function callTerrain(
     return NextResponse.json(data);
 }
 
-async function getServiceAccountToken() {
+export async function getServiceAccountToken() {
     if (
         !serviceAccountToken ||
         !serviceAccountToken.accessTokenExp ||

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -100,7 +100,10 @@ export async function getServiceAccountToken() {
             body: "grant_type=client_credentials",
         });
 
-        if (!tokenResponse.ok) {
+        if (tokenResponse.ok) {
+            const tokenData = await tokenResponse.json();
+            serviceAccountToken = tokenData;
+        } else {
             const errorJson = await parseErrorJson(tokenResponse, tokenUrl);
 
             console.error("Could not get service account token.", {
@@ -108,18 +111,11 @@ export async function getServiceAccountToken() {
             });
         }
 
-        const tokenData = await tokenResponse.json();
-        serviceAccountToken = tokenData;
-
         if (serviceAccountToken) {
             serviceAccountToken.accessTokenExp = addSeconds(
                 new Date(),
                 serviceAccountToken.expires_in,
             );
-        } else {
-            console.error("Could not get service account token.", {
-                tokenData,
-            });
         }
     }
 

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import constants from "@/constants";
 import { dateConstants, formatDate } from "@/utils/formatUtils";
 
 import { SubscriptionSummaryDetails } from "./types";
@@ -162,7 +163,11 @@ export async function serviceAccountUpdateSubscription(
 ) {
     const today = new Date();
     const currentEndDate = toDate(currentSubscription.effective_end_date);
-    const newStartDate = currentEndDate > today ? currentEndDate : today;
+    const newStartDate =
+        currentSubscription.plan.name !== constants.PLAN_NAME_BASIC &&
+        currentEndDate > today
+            ? currentEndDate
+            : today;
 
     const queryParams = new URLSearchParams({
         periods: periods.toString(),

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -1,6 +1,7 @@
 import { UUID } from "crypto";
 
 export type SubscriptionSummaryDetails = {
+    id: UUID;
     users: {
         username: string;
     };
@@ -167,6 +168,14 @@ export type OrderRequest = Pick<
     termsAcknowledged: boolean;
 };
 
+export type OrderUpdateError = {
+    method?: string;
+    url?: string;
+    status?: number;
+    message: string;
+    response?: object;
+};
+
 export type OrderUpdateResult = {
     success: boolean;
     message?: string | object;
@@ -176,13 +185,7 @@ export type OrderUpdateResult = {
         CreateTransactionResponse["transactionResponse"],
         "transId" | "errors"
     >;
-    error?: {
-        method?: string;
-        url?: string;
-        status?: number;
-        message: string;
-        response?: object;
-    };
+    error?: OrderUpdateError;
     subscription?: {
         status: string;
         result: Pick<
@@ -199,6 +202,22 @@ export type OrderUpdateResult = {
             }>;
         };
     };
+    addons?: Array<{
+        error?: OrderUpdateError;
+        subscription_addon?: {
+            uuid: UUID;
+            amount: number;
+            paid: boolean;
+            addon: {
+                name: string;
+                description: string;
+                resource_type: {
+                    name: string;
+                    unit: string;
+                };
+            };
+        };
+    }>;
 };
 
 export type TerrainError = {

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -54,6 +54,23 @@ export type PlanType = {
     }>;
 };
 
+export type AddonsType = {
+    uuid: UUID;
+    name: string;
+    description: string;
+    resource_type: {
+        name: string;
+        unit: string;
+    };
+    addon_rates: Array<{
+        rate: number;
+    }>;
+};
+
+export type AddonsList = {
+    addons: Array<AddonsType>;
+};
+
 export type SubscriptionSubmission = {
     username: string;
     plan_name: string;

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -123,6 +123,9 @@ export type TransactionRequest = {
         }>;
     };
     poNumber?: number;
+    customer?: {
+        email: string;
+    };
     billTo: {
         firstName: string;
         lastName: string;

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -101,8 +101,8 @@ export type TransactionRequest = {
             cardCode: string;
         };
     };
-    lineItems?: Array<{
-        lineItem: {
+    lineItems?: {
+        lineItem?: Array<{
             /**
              * The ID of the subscription or add-on from QMS,
              * not submitted to Authorize.net.
@@ -119,8 +119,8 @@ export type TransactionRequest = {
             description?: string;
             quantity: number;
             unitPrice: number;
-        };
-    }>;
+        }>;
+    };
     poNumber?: number;
     billTo: {
         firstName: string;

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -80,7 +80,7 @@ export type SubscriptionSubmission = {
     username: string;
     plan_name: string;
     plan_rate?: number;
-    paid: boolean;
+    paid?: boolean;
     periods: number;
     start_date?: string;
     end_date?: string;

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -39,6 +39,10 @@ export type SubscriptionSummaryDetails = {
     }>;
 };
 
+export type ResourceUsageSummary = {
+    subscription: SubscriptionSummaryDetails;
+};
+
 export type PlanType = {
     id: UUID;
     name: string;
@@ -81,6 +85,11 @@ export type SubscriptionSubmission = {
     end_date?: string;
 };
 
+export enum LineItemIDEnum {
+    SUBSCRIPTION = "subscription",
+    ADDON = "addon",
+}
+
 export type TransactionRequest = {
     transactionType: string;
     amount: number;
@@ -94,12 +103,18 @@ export type TransactionRequest = {
     };
     lineItems?: Array<{
         lineItem: {
-            // The ID of the subscription or add-on from QMS,
-            // not submitted to Authorize.net.
+            /**
+             * The ID of the subscription or add-on from QMS,
+             * not submitted to Authorize.net.
+             */
             id?: UUID;
-            // The item type (subscription or add-on).
-            itemId: string;
-            // The plan name or add-on type.
+            /**
+             * The item type ("subscription" or "addon").
+             */
+            itemId: LineItemIDEnum;
+            /**
+             * The plan name or add-on name.
+             */
             name: string;
             description?: string;
             quantity: number;

--- a/src/components/Cart.tsx
+++ b/src/components/Cart.tsx
@@ -17,7 +17,8 @@ const Cart = () => {
     const [cartInfo] = useCartInfo();
     const router = useRouter();
 
-    const badgeContent = cartInfo.subscription ? 1 : 0;
+    let badgeContent = cartInfo.addons?.length || 0;
+    badgeContent += cartInfo.subscription ? 1 : 0;
 
     return (
         <Tooltip title="Checkout">

--- a/src/components/OrderConfirmation.tsx
+++ b/src/components/OrderConfirmation.tsx
@@ -19,8 +19,12 @@ function OrderConfirmation() {
     const planName = subscription?.plan?.name;
     const startDate = subscription?.effective_start_date;
     const endDate = subscription?.effective_end_date;
+    const addons = order?.addons?.filter((addon) => !addon.error);
     const orderDate = order?.orderDate;
     const transactionId = order?.transactionResponse?.transId;
+
+    const orderError =
+        order?.error || order?.addons?.find((addon) => addon.error)?.error;
 
     return (
         <Stack spacing={2} useFlexGap>
@@ -52,11 +56,11 @@ function OrderConfirmation() {
                             }
                             errorObject={
                                 new HttpError(
-                                    order.error?.method || "",
-                                    order.error?.url || "",
-                                    order.error?.status || 500,
-                                    order.error?.message || "",
-                                    JSON.stringify(order.error?.response || {}),
+                                    orderError?.method || "",
+                                    orderError?.url || "",
+                                    orderError?.status || 500,
+                                    orderError?.message || "",
+                                    JSON.stringify(orderError?.response || {}),
                                 )
                             }
                         />
@@ -73,6 +77,11 @@ function OrderConfirmation() {
                                 <strong>&nbsp;#{order.poNumber}</strong>. We
                                 have emailed your order confirmation.
                             </Typography>
+                        </>
+                    )}
+
+                    {subscription && (
+                        <>
                             <Typography>
                                 Your ordered subscription tier is{" "}
                                 <ExternalLink
@@ -117,6 +126,30 @@ function OrderConfirmation() {
                             </Grid>
                         </>
                     )}
+
+                    {addons && addons.length > 0 && (
+                        <>
+                            <Typography>Add-ons</Typography>
+                            <Grid container>
+                                {addons.map((addon) => (
+                                    <GridLabelValue
+                                        key={addon.subscription_addon?.uuid}
+                                        label={
+                                            addon.subscription_addon?.addon.name
+                                        }
+                                    >
+                                        <Typography>
+                                            {
+                                                addon.subscription_addon?.addon
+                                                    .description
+                                            }
+                                        </Typography>
+                                    </GridLabelValue>
+                                ))}
+                            </Grid>
+                        </>
+                    )}
+
                     <Grid container>
                         {orderDate && (
                             <GridLabelValue label="Order Date">

--- a/src/components/SubscriptionSummary.tsx
+++ b/src/components/SubscriptionSummary.tsx
@@ -7,7 +7,10 @@ import {
     getResourceUsageSummary,
     RESOURCE_USAGE_QUERY_KEY,
 } from "@/app/api/serviceFacade";
-import { SubscriptionSummaryDetails } from "@/app/api/types";
+import {
+    ResourceUsageSummary,
+    SubscriptionSummaryDetails,
+} from "@/app/api/types";
 import ExternalLink from "@/components/common/ExternalLink";
 import GridLabelValue from "@/components/common/GridLabelValue";
 import GridLoading from "@/components/common/GridLoading";
@@ -51,10 +54,6 @@ const ADDONS_TABLE_COLUMNS = [
     { name: "Resource Type", numeric: false, enableSorting: false },
     { name: "Paid", numeric: false, enableSorting: false },
 ];
-
-type ResourceUsageSummary = {
-    subscription: SubscriptionSummaryDetails;
-};
 
 const SubscriptionSummary = () => {
     const [editSubscriptionOpen, setEditSubscriptionOpen] = useState(false);

--- a/src/components/SubscriptionSummary.tsx
+++ b/src/components/SubscriptionSummary.tsx
@@ -27,7 +27,7 @@ import EditAddons from "@/components/forms/EditAddons";
 import EditSubscription from "@/components/forms/EditSubscription";
 import { dateConstants, formatDate, formatFileSize } from "@/utils/formatUtils";
 
-import { addDays, toDate } from "date-fns";
+import { differenceInCalendarDays } from "date-fns";
 
 import {
     Box,
@@ -80,7 +80,7 @@ const SubscriptionSummary = () => {
     };
 
     const handleEditSubscriptionClick = () => {
-        if (!endDate || toDate(endDate) > addDays(new Date(), 30)) {
+        if (!endDate || differenceInCalendarDays(endDate, new Date()) > 30) {
             announce({
                 text: "You cannot renew your subscription more than 30 days before the end date.",
                 variant: ERROR,

--- a/src/components/SubscriptionSummary.tsx
+++ b/src/components/SubscriptionSummary.tsx
@@ -20,6 +20,7 @@ import DETableHead from "@/components/common/table/DETableHead";
 import { DERow } from "@/components/common/table/DERow";
 import EmptyTable from "@/components/common/table/EmptyTable";
 import TableLoading from "@/components/common/table/TableLoading";
+import EditAddons from "@/components/forms/EditAddons";
 import EditSubscription from "@/components/forms/EditSubscription";
 import { dateConstants, formatDate, formatFileSize } from "@/utils/formatUtils";
 
@@ -57,6 +58,7 @@ type ResourceUsageSummary = {
 
 const SubscriptionSummary = () => {
     const [editSubscriptionOpen, setEditSubscriptionOpen] = useState(false);
+    const [editAddonsOpen, setEditAddonsOpen] = useState(false);
 
     const {
         isFetching,
@@ -71,6 +73,12 @@ const SubscriptionSummary = () => {
     const currentPlanName = subscription?.plan?.name;
     const startDate = subscription?.effective_start_date;
     const endDate = subscription?.effective_end_date;
+
+    const handleEditAddonsClick = () => {
+        if (subscription) {
+            setEditAddonsOpen(true);
+        }
+    };
 
     const handleEditSubscriptionClick = () => {
         if (!endDate || toDate(endDate) > addDays(new Date(), 30)) {
@@ -178,7 +186,22 @@ const SubscriptionSummary = () => {
                         loading={isFetching}
                     />
                 </CardContent>
+                <CardActions>
+                    <Button
+                        color="primary"
+                        startIcon={<ShopIcon />}
+                        onClick={handleEditAddonsClick}
+                    >
+                        Purchase Add-ons
+                    </Button>
+                </CardActions>
             </Card>
+
+            <EditAddons
+                open={editAddonsOpen}
+                onClose={() => setEditAddonsOpen(false)}
+                subscription={subscription}
+            />
         </Grid>
     );
 };

--- a/src/components/forms/Checkout.tsx
+++ b/src/components/forms/Checkout.tsx
@@ -74,6 +74,7 @@ const steps = ["Billing address", "Payment details", "Review your order"];
 function getStepContent(
     step: number,
     checkoutCart: CartInfo,
+    subscriptionEndDate: number | undefined,
     values: CheckoutFormValues,
     setFieldValue: FieldProps["form"]["setFieldValue"],
     orderError: OrderError | null,
@@ -87,6 +88,7 @@ function getStepContent(
             return (
                 <Review
                     cartInfo={checkoutCart}
+                    subscriptionEndDate={subscriptionEndDate}
                     values={values}
                     orderError={orderError}
                 />
@@ -533,6 +535,7 @@ function Checkout({ showErrorAnnouncer }: WithErrorAnnouncerProps) {
                                     {getStepContent(
                                         activeStep,
                                         checkoutCart,
+                                        subscriptionEndDate,
                                         values,
                                         setFieldValue,
                                         orderError,

--- a/src/components/forms/Checkout.tsx
+++ b/src/components/forms/Checkout.tsx
@@ -166,7 +166,7 @@ function Checkout({ showErrorAnnouncer }: WithErrorAnnouncerProps) {
         let addonsTotal = 0;
         addons.forEach((addon) => {
             addonsTotal +=
-                addonProratedRate(subscriptionEndDate, addon) * addon.amount;
+                addonProratedRate(subscriptionEndDate, addon) * addon.quantity;
         });
 
         checkoutCart.totalPrice += addonsTotal;

--- a/src/components/forms/EditAddons.tsx
+++ b/src/components/forms/EditAddons.tsx
@@ -17,8 +17,8 @@ import { announce } from "@/components/common/announcer/CyVerseAnnouncer";
 import { SUCCESS } from "@/components/common/announcer/AnnouncerConstants";
 import { useCartInfo } from "@/contexts/cart";
 import { formatCurrency } from "@/utils/formatUtils";
+import { addonProratedRate } from "@/utils/rates";
 
-import { differenceInCalendarDays } from "date-fns";
 import { Field, FieldArray, Form, Formik } from "formik";
 import * as Yup from "yup";
 
@@ -54,11 +54,6 @@ function EditAddons({
     });
 
     const subscriptionEndDate = subscription?.effective_end_date;
-    let prorateDaysRemaining = 0;
-    if (subscriptionEndDate) {
-        prorateDaysRemaining =
-            differenceInCalendarDays(subscriptionEndDate, new Date()) / 365;
-    }
 
     return (
         <Formik
@@ -87,15 +82,12 @@ function EditAddons({
         >
             {({ handleSubmit, values }) => {
                 let subTotal = 0;
-                if (prorateDaysRemaining && values.addons) {
+                if (values.addons) {
                     values.addons.forEach((addon) => {
-                        const addonRate = addon.addon_rates[0].rate;
-                        const prorateAddonPrice = Math.floor(
-                            addonRate * prorateDaysRemaining,
-                        );
-
-                        if (prorateAddonPrice > 0 && addon.amount > 0) {
-                            subTotal += prorateAddonPrice * addon.amount;
+                        if (addon.amount > 0) {
+                            subTotal +=
+                                addonProratedRate(subscriptionEndDate, addon) *
+                                addon.amount;
                         }
                     });
                 }

--- a/src/components/forms/EditAddons.tsx
+++ b/src/components/forms/EditAddons.tsx
@@ -65,7 +65,7 @@ function EditAddons({
             validationSchema={validationSchema}
             onSubmit={(values) => {
                 const addons = values.addons?.filter(
-                    (addon) => addon.amount > 0,
+                    (addon) => addon.quantity > 0,
                 );
 
                 if (addons) {
@@ -84,10 +84,10 @@ function EditAddons({
                 let subTotal = 0;
                 if (values.addons) {
                     values.addons.forEach((addon) => {
-                        if (addon.amount > 0) {
+                        if (addon.quantity > 0) {
                             subTotal +=
                                 addonProratedRate(subscriptionEndDate, addon) *
-                                addon.amount;
+                                addon.quantity;
                         }
                     });
                 }
@@ -129,7 +129,7 @@ function EditAddons({
                                                         <AddonFormField
                                                             key={addon.uuid}
                                                             addon={addon}
-                                                            name={`addons.${index}.amount`}
+                                                            name={`addons.${index}.quantity`}
                                                         />
                                                     ),
                                                 )}

--- a/src/components/forms/EditAddons.tsx
+++ b/src/components/forms/EditAddons.tsx
@@ -1,0 +1,166 @@
+/**
+ * @author psarando
+ */
+import React from "react";
+
+import FormIntegerField from "./FormIntegerField";
+import { mapAddonsPropsToValues } from "./formatters";
+
+import { ADDONS_QUERY_KEY, getAddons } from "@/app/api/serviceFacade";
+import {
+    AddonsList,
+    AddonsType,
+    SubscriptionSummaryDetails,
+} from "@/app/api/types";
+import DEDialog from "@/components/common/DEDialog";
+import { formatCurrency } from "@/utils/formatUtils";
+
+import { differenceInCalendarDays } from "date-fns";
+import { Field, FieldArray, Form, Formik } from "formik";
+import * as Yup from "yup";
+
+import { Button, Skeleton, Typography } from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+
+function EditAddons({
+    open,
+    onClose,
+    subscription,
+}: {
+    open: boolean;
+    onClose: React.MouseEventHandler;
+    subscription: SubscriptionSummaryDetails | undefined;
+}) {
+    const { data: addonsQueryData, isFetching: loadingAddons } =
+        useQuery<AddonsList>({
+            queryKey: [ADDONS_QUERY_KEY],
+            queryFn: getAddons,
+            staleTime: Infinity,
+        });
+
+    const validationSchema = Yup.object().shape({
+        addons: Yup.array().of(
+            Yup.object().shape({
+                amount: Yup.number()
+                    .integer("Please enter a valid number.")
+                    .min(0, "Must be 0 or greater."),
+            }),
+        ),
+    });
+
+    const subscriptionEndDate = subscription?.effective_end_date;
+    let prorateDaysRemaining = 0;
+    if (subscriptionEndDate) {
+        prorateDaysRemaining =
+            differenceInCalendarDays(subscriptionEndDate, new Date()) / 365;
+    }
+
+    return (
+        <Formik
+            enableReinitialize={true}
+            initialValues={mapAddonsPropsToValues(addonsQueryData?.addons)}
+            validationSchema={validationSchema}
+            onSubmit={(values) => {
+                console.log(values);
+            }}
+        >
+            {({ handleSubmit, values }) => {
+                let subTotal = 0;
+                if (prorateDaysRemaining && values.addons) {
+                    values.addons.forEach((addon) => {
+                        const addonRate = addon.addon_rates[0].rate;
+                        const prorateAddonPrice = Math.floor(
+                            addonRate * prorateDaysRemaining,
+                        );
+
+                        if (prorateAddonPrice > 0 && addon.amount > 0) {
+                            subTotal += prorateAddonPrice * addon.amount;
+                        }
+                    });
+                }
+
+                return (
+                    <Form>
+                        <DEDialog
+                            open={open}
+                            onClose={onClose}
+                            title="Purchase Add-ons"
+                            actions={
+                                <>
+                                    <Button
+                                        onClick={onClose}
+                                        variant="outlined"
+                                    >
+                                        Cancel
+                                    </Button>
+
+                                    <Button
+                                        type="submit"
+                                        variant="contained"
+                                        onClick={() => handleSubmit()}
+                                    >
+                                        Add to Cart
+                                    </Button>
+                                </>
+                            }
+                        >
+                            {loadingAddons ? (
+                                <Skeleton variant="text" />
+                            ) : (
+                                <>
+                                    <FieldArray name="addons">
+                                        {() => (
+                                            <>
+                                                {values.addons?.map(
+                                                    (addon, index) => (
+                                                        <AddonFormField
+                                                            key={addon.uuid}
+                                                            addon={addon}
+                                                            name={`addons.${index}.amount`}
+                                                        />
+                                                    ),
+                                                )}
+                                            </>
+                                        )}
+                                    </FieldArray>
+                                    <Typography variant="caption">
+                                        * Charge amount will be proportional to
+                                        the current subscription expiration
+                                        date.
+                                    </Typography>
+                                    <Typography
+                                        variant="subtitle1"
+                                        sx={{ marginTop: 2 }}
+                                    >
+                                        Subtotal: {formatCurrency(subTotal)} USD
+                                    </Typography>
+                                </>
+                            )}
+                        </DEDialog>
+                    </Form>
+                );
+            }}
+        </Formik>
+    );
+}
+
+function AddonFormField({ addon, name }: { addon: AddonsType; name: string }) {
+    const addonRate = formatCurrency(addon.addon_rates[0].rate);
+    const resourceInBytes = addon.resource_type.unit === "bytes";
+
+    let helperText = `${addonRate} USD* per ${addon.name}`;
+    helperText += resourceInBytes
+        ? " of data storage for 1 year."
+        : ", to be used before the current subscription ends.";
+
+    return (
+        <Field
+            name={name}
+            component={FormIntegerField}
+            label={`${addon.name} Add-on (${addonRate} USD*)`}
+            helperText={helperText}
+        />
+    );
+}
+
+export default EditAddons;

--- a/src/components/forms/EditSubscription.tsx
+++ b/src/components/forms/EditSubscription.tsx
@@ -1,3 +1,6 @@
+/**
+ * @author psarando
+ */
 import React from "react";
 
 import constants from "@/constants";

--- a/src/components/forms/FormIntegerField.tsx
+++ b/src/components/forms/FormIntegerField.tsx
@@ -1,0 +1,32 @@
+/**
+ * @author psarando
+ */
+import React from "react";
+
+import FormTextField from "./FormTextField";
+
+import { FieldInputProps, FieldProps } from "formik";
+import { TextFieldProps } from "@mui/material";
+
+const onIntegerChange =
+    (onChange: FieldInputProps<TextFieldProps>["onChange"]) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+        const newValue = event.target.value;
+        const intVal = Number(newValue);
+        if (Number.isInteger(intVal)) {
+            onChange(event);
+        }
+    };
+
+const FormIntegerField = ({
+    field: { onChange, ...field },
+    ...props
+}: FieldProps) => (
+    <FormTextField
+        slotProps={{ input: { inputMode: "numeric" } }}
+        field={{ ...field, onChange: onIntegerChange(onChange) }}
+        {...props}
+    />
+);
+
+export default FormIntegerField;

--- a/src/components/forms/FormTextField.tsx
+++ b/src/components/forms/FormTextField.tsx
@@ -4,7 +4,7 @@
 import getFormError from "./getFormError";
 
 import { FieldProps } from "formik";
-import TextField from "@mui/material/TextField";
+import TextField, { TextFieldProps } from "@mui/material/TextField";
 
 const FormTextField = ({
     field,
@@ -13,7 +13,7 @@ const FormTextField = ({
     required,
     form: { touched, errors },
     ...custom
-}: FieldProps & { label: string; helperText: string; required: boolean }) => {
+}: FieldProps & TextFieldProps) => {
     const errorMsg = getFormError(field.name, touched, errors);
     return (
         <TextField

--- a/src/components/forms/Info.tsx
+++ b/src/components/forms/Info.tsx
@@ -23,13 +23,23 @@ export default function Info({
 }) {
     return (
         <React.Fragment>
-            <Typography variant="subtitle2" sx={{ color: "text.secondary" }}>
-                Total
-            </Typography>
-            <Typography variant="h4" gutterBottom>
-                {formatCurrency(cartInfo.totalPrice || 0)}
-            </Typography>
             <List disablePadding>
+                <ListItem sx={{ py: 1, px: 0 }}>
+                    <ListItemText
+                        sx={{ mr: 2 }}
+                        primary={
+                            <Typography
+                                variant="subtitle2"
+                                sx={{ color: "text.secondary" }}
+                            >
+                                Total
+                            </Typography>
+                        }
+                    />
+                    <Typography variant="h4" gutterBottom>
+                        {formatCurrency(cartInfo.totalPrice || 0)}
+                    </Typography>
+                </ListItem>
                 {cartInfo.subscription && (
                     <CartInfoListItem
                         name={`${cartInfo.subscription.plan_name} Subscription`}

--- a/src/components/forms/Info.tsx
+++ b/src/components/forms/Info.tsx
@@ -59,12 +59,12 @@ export default function Info({
                         <CartInfoListItem
                             key={addon.uuid}
                             name={`Add-on ${addon.name}`}
-                            desc={`${addon.amount} x ${formatCurrency(
+                            desc={`${addon.quantity} x ${formatCurrency(
                                 addon.addon_rates[0].rate,
                             )} prorated to the current subscription expiration date.`}
                             price={
                                 addonProratedRate(subscriptionEndDate, addon) *
-                                addon.amount
+                                addon.quantity
                             }
                         />
                     ))}

--- a/src/components/forms/Info.tsx
+++ b/src/components/forms/Info.tsx
@@ -8,12 +8,19 @@
  */
 import React from "react";
 
-import { formatCurrency } from "@/utils/formatUtils";
 import { CartInfo } from "@/contexts/cart";
+import { formatCurrency } from "@/utils/formatUtils";
+import { addonProratedRate } from "@/utils/rates";
 
 import { List, ListItem, ListItemText, Typography } from "@mui/material";
 
-export default function Info({ cartInfo }: { cartInfo: CartInfo }) {
+export default function Info({
+    cartInfo,
+    subscriptionEndDate,
+}: {
+    cartInfo: CartInfo;
+    subscriptionEndDate?: number;
+}) {
     return (
         <React.Fragment>
             <Typography variant="subtitle2" sx={{ color: "text.secondary" }}>
@@ -24,31 +31,53 @@ export default function Info({ cartInfo }: { cartInfo: CartInfo }) {
             </Typography>
             <List disablePadding>
                 {cartInfo.subscription && (
-                    <ListItem
-                        key={cartInfo.subscription.plan_name}
-                        sx={{ py: 1, px: 0 }}
-                    >
-                        <ListItemText
-                            sx={{ mr: 2 }}
-                            primary={`${cartInfo.subscription.plan_name} Subscription`}
-                            secondary={
-                                cartInfo.subscription.periods === 1
-                                    ? "1 Year"
-                                    : "2 Years"
+                    <CartInfoListItem
+                        name={`${cartInfo.subscription.plan_name} Subscription`}
+                        desc={
+                            cartInfo.subscription.periods === 1
+                                ? "1 Year"
+                                : "2 Years"
+                        }
+                        price={
+                            (cartInfo.subscription.plan_rate || 0) *
+                            cartInfo.subscription.periods
+                        }
+                    />
+                )}
+                {cartInfo.addons &&
+                    cartInfo.addons.map((addon) => (
+                        <CartInfoListItem
+                            key={addon.uuid}
+                            name={`Add-on ${addon.name}`}
+                            desc={`${addon.amount} x ${formatCurrency(
+                                addon.addon_rates[0].rate,
+                            )} prorated to the current subscription expiration date.`}
+                            price={
+                                addonProratedRate(subscriptionEndDate, addon) *
+                                addon.amount
                             }
                         />
-                        <Typography
-                            variant="body1"
-                            sx={{ fontWeight: "medium" }}
-                        >
-                            {formatCurrency(
-                                (cartInfo.subscription.plan_rate || 0) *
-                                    cartInfo.subscription.periods,
-                            )}
-                        </Typography>
-                    </ListItem>
-                )}
+                    ))}
             </List>
         </React.Fragment>
+    );
+}
+
+function CartInfoListItem({
+    name,
+    desc,
+    price,
+}: {
+    name: string;
+    desc: string;
+    price: number;
+}) {
+    return (
+        <ListItem sx={{ py: 1, px: 0 }}>
+            <ListItemText sx={{ mr: 2 }} primary={name} secondary={desc} />
+            <Typography variant="body1" sx={{ fontWeight: "medium" }}>
+                {formatCurrency(price)}
+            </Typography>
+        </ListItem>
     );
 }

--- a/src/components/forms/InfoMobile.tsx
+++ b/src/components/forms/InfoMobile.tsx
@@ -16,7 +16,13 @@ import { Box, Button, Drawer, IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
 
-export default function InfoMobile({ cartInfo }: { cartInfo: CartInfo }) {
+export default function InfoMobile({
+    cartInfo,
+    subscriptionEndDate,
+}: {
+    cartInfo: CartInfo;
+    subscriptionEndDate?: number;
+}) {
     const [open, setOpen] = React.useState(false);
 
     const toggleDrawer = (newOpen: boolean) => () => {
@@ -31,7 +37,10 @@ export default function InfoMobile({ cartInfo }: { cartInfo: CartInfo }) {
             >
                 <CloseIcon />
             </IconButton>
-            <Info cartInfo={cartInfo} />
+            <Info
+                cartInfo={cartInfo}
+                subscriptionEndDate={subscriptionEndDate}
+            />
         </Box>
     );
 

--- a/src/components/forms/Review.tsx
+++ b/src/components/forms/Review.tsx
@@ -10,55 +10,36 @@ import constants from "@/constants";
 import { OrderError } from "@/app/api/types";
 import { CartInfo } from "@/contexts/cart";
 import ExternalLink from "@/components/common/ExternalLink";
-import { formatCurrency } from "@/utils/formatUtils";
 
 import FormCheckbox from "./FormCheckbox";
 import { CheckoutFormValues } from "./formatters";
+import Info from "./Info";
 import OrderErrorCard from "./OrderErrorCard";
 
 import { Field } from "formik";
 
-import {
-    Divider,
-    List,
-    ListItem,
-    ListItemText,
-    Stack,
-    Typography,
-} from "@mui/material";
+import { Box, Divider, Stack, Typography } from "@mui/material";
 
 export default function Review({
     cartInfo,
+    subscriptionEndDate,
     values,
     orderError,
 }: {
     cartInfo: CartInfo;
+    subscriptionEndDate?: number;
     values: CheckoutFormValues;
     orderError: OrderError | null;
 }) {
     return (
         <Stack spacing={2}>
-            <List disablePadding>
-                {cartInfo.subscription && (
-                    <ListItem sx={{ py: 1, px: 0 }}>
-                        <ListItemText
-                            primary={`${cartInfo.subscription?.plan_name} Subscription`}
-                            secondary={
-                                cartInfo.subscription?.periods === 2
-                                    ? "2 Years"
-                                    : "1 Year"
-                            }
-                        />
-                        <Typography variant="body2">
-                            {formatCurrency(
-                                (cartInfo.subscription?.plan_rate || 0) *
-                                    (cartInfo.subscription?.periods || 1),
-                            )}
-                        </Typography>
-                    </ListItem>
-                )}
-            </List>
-            <Divider />
+            <Box sx={{ display: { xs: "flex", md: "none" } }}>
+                <Info
+                    cartInfo={cartInfo}
+                    subscriptionEndDate={subscriptionEndDate}
+                />
+            </Box>
+            <Divider sx={{ display: { xs: "flex", md: "none" } }} />
             <Stack
                 direction="column"
                 divider={<Divider flexItem />}

--- a/src/components/forms/formatters.ts
+++ b/src/components/forms/formatters.ts
@@ -7,7 +7,6 @@ import {
     SubscriptionSummaryDetails,
 } from "@/app/api/types";
 import { CartInfo } from "@/contexts/cart";
-import { dateConstants, formatDate } from "@/utils/formatUtils";
 import { addonProratedRate } from "@/utils/rates";
 
 export type SubscriptionFormValues = {
@@ -34,24 +33,13 @@ export function formatSubscription(
 
     const {
         users: { username },
-        effective_end_date,
     } = subscription;
-
-    const currentEndDate = new Date(effective_end_date);
 
     const submission: SubscriptionSubmission = {
         username,
         plan_name,
-        paid: true,
         periods,
     };
-
-    if (currentEndDate > new Date()) {
-        submission.start_date = formatDate(
-            currentEndDate,
-            dateConstants.ISO_8601,
-        );
-    }
 
     return submission;
 }

--- a/src/components/forms/formatters.ts
+++ b/src/components/forms/formatters.ts
@@ -57,7 +57,7 @@ export function formatSubscription(
 }
 
 export type AddonsFormValues = {
-    addons?: Array<AddonsType & { amount: number }>;
+    addons?: Array<AddonsType & { quantity: number }>;
 };
 
 export function mapAddonsPropsToValues(
@@ -66,9 +66,9 @@ export function mapAddonsPropsToValues(
 ): AddonsFormValues {
     return {
         addons: addons?.map((addon) => ({
-            amount:
-                cartInfo?.addons?.find((a) => a.uuid === addon.uuid)?.amount ||
-                0,
+            quantity:
+                cartInfo?.addons?.find((a) => a.uuid === addon.uuid)
+                    ?.quantity || 0,
             ...addon,
         })),
     };
@@ -138,11 +138,11 @@ export function formatCheckoutTransactionRequest(
                 itemId: LineItemIDEnum.ADDON,
                 name: addon.name,
                 description:
-                    `${addon.amount} x ${addon.name} for user "${username}".`.substring(
+                    `${addon.quantity} x ${addon.name} for user "${username}".`.substring(
                         0,
                         255,
                     ),
-                quantity: addon.amount,
+                quantity: addon.quantity,
                 unitPrice: addonProratedRate(subscriptionEndDate, addon),
             }),
         );

--- a/src/components/forms/formatters.ts
+++ b/src/components/forms/formatters.ts
@@ -60,8 +60,16 @@ export type AddonsFormValues = {
 
 export function mapAddonsPropsToValues(
     addons?: AddonsList["addons"],
+    cartInfo?: CartInfo,
 ): AddonsFormValues {
-    return { addons: addons?.map((addon) => ({ amount: 0, ...addon })) };
+    return {
+        addons: addons?.map((addon) => ({
+            amount:
+                cartInfo?.addons?.find((a) => a.uuid === addon.uuid)?.amount ||
+                0,
+            ...addon,
+        })),
+    };
 }
 
 export type CheckoutFormValues = Pick<

--- a/src/components/forms/formatters.ts
+++ b/src/components/forms/formatters.ts
@@ -114,40 +114,36 @@ export function formatCheckoutTransactionRequest(
         ...values,
         amount: cartInfo.totalPrice || 0,
         currencyCode: "USD",
-        lineItems: [],
+        lineItems: { lineItem: [] },
     };
 
     if (subscription) {
-        request.lineItems?.push({
-            lineItem: {
-                itemId: LineItemIDEnum.SUBSCRIPTION,
-                name: subscription.plan_name,
-                description:
-                    `${subscription.periods}-year Subscription for user "${username}".`.substring(
-                        0,
-                        255,
-                    ),
-                quantity: subscription.periods,
-                unitPrice: subscription.plan_rate || 0,
-            },
+        request.lineItems?.lineItem?.push({
+            itemId: LineItemIDEnum.SUBSCRIPTION,
+            name: subscription.plan_name,
+            description:
+                `${subscription.periods}-year Subscription for user "${username}".`.substring(
+                    0,
+                    255,
+                ),
+            quantity: subscription.periods,
+            unitPrice: subscription.plan_rate || 0,
         });
     }
 
     if (addons) {
         addons.forEach((addon) =>
-            request.lineItems?.push({
-                lineItem: {
-                    id: addon.uuid,
-                    itemId: LineItemIDEnum.ADDON,
-                    name: addon.name,
-                    description:
-                        `${addon.amount} x ${addon.name} for user "${username}".`.substring(
-                            0,
-                            255,
-                        ),
-                    quantity: addon.amount,
-                    unitPrice: addonProratedRate(subscriptionEndDate, addon),
-                },
+            request.lineItems?.lineItem?.push({
+                id: addon.uuid,
+                itemId: LineItemIDEnum.ADDON,
+                name: addon.name,
+                description:
+                    `${addon.amount} x ${addon.name} for user "${username}".`.substring(
+                        0,
+                        255,
+                    ),
+                quantity: addon.amount,
+                unitPrice: addonProratedRate(subscriptionEndDate, addon),
             }),
         );
     }

--- a/src/components/forms/formatters.ts
+++ b/src/components/forms/formatters.ts
@@ -1,4 +1,6 @@
 import {
+    AddonsList,
+    AddonsType,
     OrderRequest,
     SubscriptionSubmission,
     SubscriptionSummaryDetails,
@@ -50,6 +52,16 @@ export function formatSubscription(
     }
 
     return submission;
+}
+
+export type AddonsFormValues = {
+    addons?: Array<AddonsType & { amount: number }>;
+};
+
+export function mapAddonsPropsToValues(
+    addons?: AddonsList["addons"],
+): AddonsFormValues {
+    return { addons: addons?.map((addon) => ({ amount: 0, ...addon })) };
 }
 
 export type CheckoutFormValues = Pick<

--- a/src/contexts/cart.tsx
+++ b/src/contexts/cart.tsx
@@ -6,9 +6,11 @@
 import React from "react";
 
 import { OrderUpdateResult, SubscriptionSubmission } from "@/app/api/types";
+import { AddonsFormValues } from "@/components/forms/formatters";
 
 export type CartInfo = {
     subscription?: SubscriptionSubmission;
+    addons?: AddonsFormValues["addons"];
     totalPrice?: number;
     order?: OrderUpdateResult;
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -348,25 +348,31 @@ export async function addTransactionResponse(
     let responseId: UUID | undefined;
 
     try {
+        const { transactionResponse, messages } = response;
+
+        if (!transactionResponse) {
+            console.error(
+                "No transactionResponse found in CreateTransactionResponse.",
+            );
+            return responseId;
+        }
+
         const {
-            transactionResponse: {
-                responseCode,
-                authCode,
-                avsResultCode,
-                cvvResultCode,
-                cavvResultCode,
-                transId,
-                refTransID,
-                testRequest,
-                accountNumber,
-                accountType,
-                transHashSha2,
-                SupplementalDataQualificationIndicator,
-                networkTransId,
-                errors,
-            },
-            messages,
-        } = response;
+            responseCode,
+            authCode,
+            avsResultCode,
+            cvvResultCode,
+            cavvResultCode,
+            transId,
+            refTransID,
+            testRequest,
+            accountNumber,
+            accountType,
+            transHashSha2,
+            SupplementalDataQualificationIndicator,
+            networkTransId,
+            errors,
+        } = transactionResponse || {};
 
         const { rows } = await db.query<TransactionResponse>(
             `INSERT INTO transaction_responses (

--- a/src/db.ts
+++ b/src/db.ts
@@ -265,14 +265,12 @@ async function addLineItems(
     purchaseId: string,
     lineItems: OrderRequest["lineItems"],
 ) {
-    if (!lineItems || lineItems?.length < 1) {
+    if (!lineItems?.lineItem || lineItems.lineItem.length < 1) {
         return;
     }
 
-    const lineItemPromises = lineItems.map(
-        ({
-            lineItem: { id, itemId, name, description, quantity, unitPrice },
-        }) =>
+    const lineItemPromises = lineItems.lineItem.map(
+        ({ id, itemId, name, description, quantity, unitPrice }) =>
             db.query<LineItem>(
                 `INSERT INTO line_items (
                     purchase_id,
@@ -299,7 +297,7 @@ async function addLineItems(
         QueryResult<PurchasedSubscription>
     >[] = [];
 
-    lineItems.forEach(({ lineItem: { id, itemId } }) => {
+    lineItems.lineItem.forEach(({ id, itemId }) => {
         if (itemId === "subscription") {
             purchasedSubscriptionPromises.push(
                 db.query<PurchasedSubscription>(

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -44,4 +44,4 @@ export const formatFileSize = (size: number) => {
 export const formatUsage = (usage: number) => numeral(usage).format("0.00000");
 
 export const formatCurrency = (amount: number) =>
-    numeral(amount).format("$0,0.00");
+    numeral(amount).format("$0,0");

--- a/src/utils/rates.ts
+++ b/src/utils/rates.ts
@@ -1,0 +1,26 @@
+/**
+ * @author psarando
+ */
+import { AddonsType } from "@/app/api/types";
+import { DateArg, differenceInCalendarDays } from "date-fns";
+
+export const addonProratedRate = (
+    subscriptionEndDate?: DateArg<Date>,
+    addon?: AddonsType,
+) => {
+    let prorateDaysRemaining = 0;
+
+    if (subscriptionEndDate) {
+        prorateDaysRemaining =
+            differenceInCalendarDays(subscriptionEndDate, new Date()) / 365;
+    }
+
+    if (prorateDaysRemaining && addon) {
+        const addonRate = addon.addon_rates[0].rate;
+        const prorateAddonPrice = Math.floor(addonRate * prorateDaysRemaining);
+
+        return prorateAddonPrice;
+    }
+
+    return 0;
+};

--- a/src/validation.tsx
+++ b/src/validation.tsx
@@ -61,9 +61,9 @@ export const OrderRequestSchema: Yup.ObjectSchema<OrderRequest> =
                 .required("Currency code is required")
                 .trim()
                 .length(3, "Please use a 3 character currency code"),
-            lineItems: Yup.array().of(
-                Yup.object().shape({
-                    lineItem: Yup.object().shape({
+            lineItems: Yup.object().shape({
+                lineItem: Yup.array().of(
+                    Yup.object().shape({
                         id: Yup.string<UUID>().uuid(),
                         itemId: schemaRequiredStringMaxLen(
                             "Line Item ID is required",
@@ -81,7 +81,7 @@ export const OrderRequestSchema: Yup.ObjectSchema<OrderRequest> =
                             .required("Line Item Unit Price is required")
                             .positive("Line Item Unit Price must be positive"),
                     }),
-                }),
-            ),
+                ),
+            }),
         }),
     );

--- a/src/validation.tsx
+++ b/src/validation.tsx
@@ -1,6 +1,7 @@
-import { OrderRequest } from "@/app/api/types";
+import { LineItemIDEnum, OrderRequest } from "@/app/api/types";
 import { CheckoutFormValues } from "@/components/forms/formatters";
 
+import { UUID } from "crypto";
 import * as Yup from "yup";
 
 const schemaStringMaxLen = (label: string, max: number) =>
@@ -63,10 +64,11 @@ export const OrderRequestSchema: Yup.ObjectSchema<OrderRequest> =
             lineItems: Yup.array().of(
                 Yup.object().shape({
                     lineItem: Yup.object().shape({
+                        id: Yup.string<UUID>().uuid(),
                         itemId: schemaRequiredStringMaxLen(
                             "Line Item ID is required",
                             31,
-                        ),
+                        ).oneOf(Object.values(LineItemIDEnum)),
                         name: schemaRequiredStringMaxLen(
                             "Line Item Name is required",
                             30,


### PR DESCRIPTION
This PR will add Add-on purchase support with the following changes:

* Add Add-ons form.
* Add `/api/subscriptions/addons` route.
* Update Checkout page with Add-ons.
* Update `/api/order/route` for Add-ons.
* Update the database with purchased Add-ons.
* Update Order confirmation page for Add-ons.

This PR will also fix new subscription start dates for `Basic` subscribers and include the user's email in Authorize.net requests.

---

The following screenshots are for a subscription with 6 months remaining until the end of the subscription:
<img width="1024" height="768" alt="Add-ons form" src="https://github.com/user-attachments/assets/000576d2-a557-4cd5-a556-7bf3ff4a0052" />

---

<img width="1024" height="768" alt="Add-ons Checkout" src="https://github.com/user-attachments/assets/7a365f4a-14b9-4892-bbe2-4b7c21155bc5" />

---

Checkout on mobile:

<img width="375" height="812" alt="image" src="https://github.com/user-attachments/assets/7a829b3e-6d4c-4fa4-a281-003786a0a35f" />

---

<img width="1024" height="360" alt="Add-ons Order Confirmation page" src="https://github.com/user-attachments/assets/453f8816-8a2b-4681-a46b-ce44a58aecf5" />

---

If the user wants to upgrade / renew a subscription and purchase add-ons with 30 days remaining on their current subscription:

---

<img width="1024" height="768" alt="Subscription plus Add-ons Checkout" src="https://github.com/user-attachments/assets/7f5dd110-2de5-4c01-a80c-7297b75b45a3" />

---

<img width="1024" height="768" alt="Subscription plus Add-ons Order Confirmation page" src="https://github.com/user-attachments/assets/2184908c-5166-4331-b6af-e174cc7829df" />
