### PR TITLE
CORE-2070 Send order confirmation/error emails

### DIFF
--- a/k8s/subscription-portal.yml
+++ b/k8s/subscription-portal.yml
@@ -65,6 +65,11 @@ spec:
                 secretKeyRef:
                   name: subscription-portal-configs
                   key: SP_TERRAIN_BASE_URL
+            - name: SP_CYVERSE_SUPPORT_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: subscription-portal-configs
+                  key: SP_CYVERSE_SUPPORT_EMAIL
             - name: SP_KEYCLOAK_ISSUER
               valueFrom:
                 secretKeyRef:

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,12 @@ const appConfiguration = {
         isPublic: true,
         defaultValue: "https://de.cyverse.org/terrain",
     },
+    supportEmail: {
+        variable: "SP_CYVERSE_SUPPORT_EMAIL",
+        required: false,
+        isPublic: false,
+        defaultValue: "support@cyverse.org",
+    },
     dbDatabase: {
         variable: "DB_DATABASE",
         required: true,

--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -12,6 +12,7 @@ import {
     TransactionRequest,
 } from "@/app/api/types";
 import {
+    serviceAccountEmailReceipt,
     serviceAccountFetchAddons,
     serviceAccountUpdateAddons,
     serviceAccountUpdateSubscription,
@@ -354,6 +355,13 @@ export async function POST(request: NextRequest) {
             success: responseJson.success && addonsUpdateResult.success,
         };
     }
+
+    await serviceAccountEmailReceipt(
+        session.user?.username || "",
+        session.user?.email || "",
+        lineItems,
+        responseJson,
+    );
 
     return NextResponse.json(responseJson);
 }


### PR DESCRIPTION
Added a `serviceAccountEmailReceipt` function for sending order confirmation to the user on successful orders,
or error emails to support.

Also added a `SP_CYVERSE_SUPPORT_EMAIL` config.