### PR TITLE
CORE-2070 Update subscription purchase emails with additional info

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,21 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
+import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
 import pluginQuery from "@tanstack/eslint-plugin-query";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
+    // import.meta.dirname is available after Node.js v20.11.0
+    baseDirectory: import.meta.dirname,
+    recommendedConfig: js.configs.recommended,
 });
 
 const eslintConfig = [
     ...pluginQuery.configs["flat/recommended"],
-    ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
+    ...compat.extends(
+        "eslint:recommended",
+        "next/core-web-vitals",
+        "next/typescript",
+        "prettier",
+    ),
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "lint": "next lint",
         "format": "prettier --write './**/*.js' './**/*.mjs' './**/*.ts' './**/*.tsx'",
         "check-format": "prettier -c './**/*.js' './**/*.mjs' './**/*.ts' './**/*.tsx'",
-        "check": "npm run lint && npm run check-format"
+        "check-typescript": "npx tsc --noEmit",
+        "check": "npm run lint && npm run check-format && npm run check-typescript"
     },
     "dependencies": {
         "@emotion/cache": "^11.14.0",

--- a/src/app/api/order/route.ts
+++ b/src/app/api/order/route.ts
@@ -403,7 +403,7 @@ export async function POST(request: NextRequest) {
     serviceAccountEmailReceipt(
         session.user?.username || "",
         session.user?.email || "",
-        lineItems,
+        orderRequest,
         responseJson,
     );
 

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -285,6 +285,7 @@ export async function serviceAccountEmailReceipt(
         transactionResponse,
         subscription,
         addons,
+        error,
     }: OrderUpdateResult,
 ) {
     const { amount, lineItems, billTo } = orderRequest;
@@ -368,6 +369,7 @@ export async function serviceAccountEmailReceipt(
                         poNumber,
                         transactionId: transactionResponse?.transId,
                         lineItems,
+                        error,
                         subscription,
                         addons,
                     },

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -349,14 +349,13 @@ export async function serviceAccountEmailReceipt(
         values,
     };
 
-    serviceAccountSendEmail({ ...body, to: email });
+    serviceAccountSendEmail({
+        ...body,
+        to: email,
+        bcc: [serverRuntimeConfig.supportEmail],
+    });
 
-    if (success) {
-        serviceAccountSendEmail({
-            ...body,
-            to: serverRuntimeConfig.supportEmail,
-        });
-    } else {
+    if (!success) {
         serviceAccountSendEmail({
             ...body,
             to: serverRuntimeConfig.supportEmail,

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -1,11 +1,17 @@
 import { auth } from "@/auth";
 import constants from "@/constants";
-import { dateConstants, formatDate } from "@/utils/formatUtils";
+import {
+    dateConstants,
+    formatCurrency,
+    formatDate,
+    formatQuota,
+} from "@/utils/formatUtils";
 
 import {
+    LineItemIDEnum,
+    OrderRequest,
     OrderUpdateResult,
     SubscriptionSummaryDetails,
-    TransactionRequest,
 } from "./types";
 
 import { addSeconds, toDate } from "date-fns";
@@ -271,7 +277,7 @@ export async function serviceAccountUpdateAddons(
 export async function serviceAccountEmailReceipt(
     username: string,
     email: string,
-    lineItems: TransactionRequest["lineItems"] | undefined,
+    orderRequest: OrderRequest,
     {
         success,
         poNumber,
@@ -281,14 +287,60 @@ export async function serviceAccountEmailReceipt(
         addons,
     }: OrderUpdateResult,
 ) {
+    const { amount, lineItems, billTo } = orderRequest;
+    const orderedSubscription = orderRequest.lineItems?.lineItem?.find(
+        (item) => item.itemId === LineItemIDEnum.SUBSCRIPTION,
+    );
+
     const values = {
+        Amount: formatCurrency(amount),
         PoNumber: poNumber,
         PurchaseTime: formatDate(
             new Date(orderDate as Date),
             dateConstants.ISO_8601,
         ),
         TransactionId: transactionResponse?.transId,
+        BillToName: `${billTo.firstName} ${billTo.lastName}`,
+        BillToCompany: billTo.company,
+        BillToAddress: [
+            billTo.address,
+            billTo.city,
+            billTo.state,
+            billTo.zip,
+            billTo.country,
+        ].join(", "),
+        CardType: transactionResponse?.accountType,
+        CardNumberEnding: transactionResponse?.accountNumber,
+        CardExpiration: orderRequest.payment.creditCard.expirationDate,
         SubscriptionLevel: subscription?.result.plan.name,
+        SubscriptionPeriod:
+            orderedSubscription?.quantity === 1 ? "1 Year" : "2 Years",
+        SubscriptionPrice: formatCurrency(orderedSubscription?.unitPrice),
+        SubscriptionStartDate: subscription
+            ? formatDate(
+                  subscription.result.effective_start_date,
+                  dateConstants.DATE_FORMAT,
+              )
+            : undefined,
+        SubscriptionEndDate: subscription
+            ? formatDate(
+                  subscription.result.effective_end_date,
+                  dateConstants.DATE_FORMAT,
+              )
+            : undefined,
+        SubscriptionQuotas: subscription?.result.quotas.map((item) =>
+            formatQuota(item.quota, item.resource_type.unit),
+        ),
+        Addons: addons?.map((addon) => {
+            const orderedAddon = orderRequest.lineItems?.lineItem?.find(
+                (item) => item.id === addon.subscription_addon?.uuid,
+            );
+            return {
+                Name: addon.subscription_addon?.addon.name,
+                Quantity: orderedAddon?.quantity,
+                Price: formatCurrency(orderedAddon?.unitPrice),
+            };
+        }),
     };
 
     const body = {
@@ -314,7 +366,14 @@ export async function serviceAccountEmailReceipt(
             values: {
                 ...values,
                 SubscriptionDetails: JSON.stringify(
-                    { username, lineItems, subscription, addons },
+                    {
+                        username,
+                        poNumber,
+                        transactionId: transactionResponse?.transId,
+                        lineItems,
+                        subscription,
+                        addons,
+                    },
                     null,
                     2,
                 ),

--- a/src/app/api/terrain.ts
+++ b/src/app/api/terrain.ts
@@ -86,7 +86,7 @@ export async function callTerrain(
     return NextResponse.json(data);
 }
 
-export async function getServiceAccountToken() {
+async function getServiceAccountToken() {
     if (
         !serviceAccountToken ||
         !serviceAccountToken.accessTokenExp ||
@@ -133,7 +133,7 @@ export async function getServiceAccountToken() {
     return serviceAccountToken?.access_token;
 }
 
-export async function serviceAccountCallTerrain(
+async function serviceAccountCallTerrain(
     method: string,
     url: string,
     body?: BodyInit,

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -194,7 +194,7 @@ export type OrderUpdateResult = {
     orderDate?: Date | string;
     transactionResponse?: Pick<
         CreateTransactionResponse["transactionResponse"],
-        "transId" | "errors"
+        "transId" | "accountNumber" | "accountType" | "errors"
     >;
     error?: OrderUpdateError;
     subscription?: {

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -8,8 +8,8 @@ export type SubscriptionSummaryDetails = {
     plan: {
         name: string;
     };
-    effective_start_date: number;
-    effective_end_date: number;
+    effective_start_date: string;
+    effective_end_date: string;
     quotas: Array<{
         id: UUID;
         quota: number;

--- a/src/components/OrderConfirmation.tsx
+++ b/src/components/OrderConfirmation.tsx
@@ -5,9 +5,8 @@ import { useCartInfo } from "@/contexts/cart";
 import { HttpError } from "@/app/api/serviceFacade";
 import ExternalLink from "@/components/common/ExternalLink";
 import GridLabelValue from "@/components/common/GridLabelValue";
-import { FormattedQuota } from "@/components/common/QuotaDetails";
 import ErrorTypographyWithDialog from "@/components/common/error/ErrorTypographyWithDialog";
-import { dateConstants, formatDate } from "@/utils/formatUtils";
+import { dateConstants, formatDate, formatQuota } from "@/utils/formatUtils";
 
 import { Grid, Stack, Typography } from "@mui/material";
 
@@ -114,13 +113,12 @@ function OrderConfirmation() {
                                     {subscription &&
                                         subscription.quotas.length > 0 &&
                                         subscription.quotas.map((item) => (
-                                            <FormattedQuota
-                                                key={item.id}
-                                                quota={item.quota}
-                                                resourceUnit={
-                                                    item.resource_type.unit
-                                                }
-                                            />
+                                            <Typography key={item.id}>
+                                                {formatQuota(
+                                                    item.quota,
+                                                    item.resource_type.unit,
+                                                )}
+                                            </Typography>
                                         ))}
                                 </GridLabelValue>
                             </Grid>

--- a/src/components/common/QuotaDetails.tsx
+++ b/src/components/common/QuotaDetails.tsx
@@ -1,26 +1,7 @@
 import { SubscriptionSummaryDetails } from "@/app/api/types";
-import { formatFileSize } from "@/utils/formatUtils";
+import { formatQuota } from "@/utils/formatUtils";
 
 import { Typography } from "@mui/material";
-
-export const FormattedQuota = ({
-    quota,
-    resourceUnit,
-}: {
-    quota: number;
-    resourceUnit: string;
-}) => {
-    // Only format data storage resources to human readable format
-    const resourceInBytes = resourceUnit.toLowerCase() === "bytes";
-
-    return (
-        <Typography>
-            {resourceInBytes
-                ? formatFileSize(quota)
-                : `${quota} ${resourceUnit} `}
-        </Typography>
-    );
-};
 
 const QuotaDetails = ({
     subscription,
@@ -32,11 +13,12 @@ const QuotaDetails = ({
             {subscription &&
                 subscription.quotas.length > 0 &&
                 subscription.quotas.map((item) => (
-                    <FormattedQuota
-                        key={item.id}
-                        quota={item.quota}
-                        resourceUnit={item.resource_type.description}
-                    />
+                    <Typography key={item.id}>
+                        {formatQuota(
+                            item.quota,
+                            item.resource_type.description,
+                        )}
+                    </Typography>
                 ))}
         </>
     );

--- a/src/components/forms/Checkout.tsx
+++ b/src/components/forms/Checkout.tsx
@@ -74,7 +74,7 @@ const steps = ["Billing address", "Payment details", "Review your order"];
 function getStepContent(
     step: number,
     checkoutCart: CartInfo,
-    subscriptionEndDate: number | undefined,
+    subscriptionEndDate: string | undefined,
     values: CheckoutFormValues,
     setFieldValue: FieldProps["form"]["setFieldValue"],
     orderError: OrderError | null,

--- a/src/components/forms/EditSubscription.tsx
+++ b/src/components/forms/EditSubscription.tsx
@@ -12,11 +12,13 @@ import { PlanType, SubscriptionSummaryDetails } from "@/app/api/types";
 
 import DEDialog from "@/components/common/DEDialog";
 import GridLabelValue from "@/components/common/GridLabelValue";
-import QuotaDetails, { FormattedQuota } from "@/components/common/QuotaDetails";
+import QuotaDetails from "@/components/common/QuotaDetails";
 import UsageDetails from "@/components/common/UsageDetails";
 import { announce } from "@/components/common/announcer/CyVerseAnnouncer";
 import { SUCCESS } from "@/components/common/announcer/AnnouncerConstants";
 import FormTextField from "@/components/forms/FormTextField";
+
+import { formatQuota } from "@/utils/formatUtils";
 
 import { mapSubscriptionPropsToValues, formatSubscription } from "./formatters";
 
@@ -209,11 +211,9 @@ const PlanQuotaDetails = ({ planType }: { planType?: PlanType }) => {
             {planType &&
                 planType?.plan_quota_defaults.length > 0 &&
                 planType.plan_quota_defaults.map((item) => (
-                    <FormattedQuota
-                        key={item.id}
-                        quota={item.quota_value}
-                        resourceUnit={item.resource_type.unit}
-                    />
+                    <Typography key={item.id}>
+                        {formatQuota(item.quota_value, item.resource_type.unit)}
+                    </Typography>
                 ))}
         </>
     );

--- a/src/components/forms/Info.tsx
+++ b/src/components/forms/Info.tsx
@@ -19,7 +19,7 @@ export default function Info({
     subscriptionEndDate,
 }: {
     cartInfo: CartInfo;
-    subscriptionEndDate?: number;
+    subscriptionEndDate?: string;
 }) {
     return (
         <React.Fragment>

--- a/src/components/forms/InfoMobile.tsx
+++ b/src/components/forms/InfoMobile.tsx
@@ -21,7 +21,7 @@ export default function InfoMobile({
     subscriptionEndDate,
 }: {
     cartInfo: CartInfo;
-    subscriptionEndDate?: number;
+    subscriptionEndDate?: string;
 }) {
     const [open, setOpen] = React.useState(false);
 

--- a/src/components/forms/Review.tsx
+++ b/src/components/forms/Review.tsx
@@ -27,7 +27,7 @@ export default function Review({
     orderError,
 }: {
     cartInfo: CartInfo;
-    subscriptionEndDate?: number;
+    subscriptionEndDate?: string;
     values: CheckoutFormValues;
     orderError: OrderError | null;
 }) {

--- a/src/components/forms/formatters.ts
+++ b/src/components/forms/formatters.ts
@@ -92,7 +92,7 @@ export function formatCheckoutFormValues(): CheckoutFormValues {
 
 export function formatCheckoutTransactionRequest(
     username: string,
-    subscriptionEndDate: number | undefined,
+    subscriptionEndDate: string | undefined,
     cartInfo: CartInfo,
     values: CheckoutFormValues,
 ): OrderRequest {

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -43,5 +43,14 @@ export const formatFileSize = (size: number) => {
 
 export const formatUsage = (usage: number) => numeral(usage).format("0.00000");
 
-export const formatCurrency = (amount: number) =>
+export const formatCurrency = (amount?: number) =>
     numeral(amount).format("$0,0");
+
+export const formatQuota = (quota: number, resourceUnit: string) => {
+    // Only format data storage resources to human readable format
+    const resourceInBytes = resourceUnit.toLowerCase() === "bytes";
+
+    return resourceInBytes
+        ? formatFileSize(quota)
+        : `${quota} ${resourceUnit} `;
+};


### PR DESCRIPTION
This PR will update the subscription purchase emails sent to users and admins with additional info, such as items ordered, prices, and payment info (supported by cyverse-de/de-mailer#20).

This PR will also BCC support admins subscription purchase emails instead of sending a separate email to them.

These changes also include updates to the `eslint.config` and `typescript` checks in the npm `check` script.
