### PR TITLE
CORE-2138 Add admin page with maintenance switch

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,17 @@
+import { auth } from "@/auth";
+import { maintenanceEnabled } from "@/db";
+import AdminSettings from "@/components/AdminSettings";
+import { NotAuthorizedCard } from "@/components/common/error/ErrorHandler";
+
+export default async function AdminPage() {
+    const session = await auth();
+    const admin = session?.user?.admin;
+
+    if (!admin) {
+        return <NotAuthorizedCard />;
+    }
+
+    const maintenance = await maintenanceEnabled();
+
+    return <AdminSettings maintenance={maintenance} />;
+}

--- a/src/app/api/admin/maintenance/route.ts
+++ b/src/app/api/admin/maintenance/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/auth";
+import { toggleMaintenanceMode } from "@/db";
+
+export async function POST() {
+    const session = await auth();
+    const user = session?.user;
+
+    if (!user) {
+        return NextResponse.json(
+            { message: "Sign In Required" },
+            { status: 401 },
+        );
+    }
+
+    if (!user.admin) {
+        return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+    }
+
+    const maintenance = await toggleMaintenanceMode();
+
+    return NextResponse.json({ maintenance });
+}

--- a/src/app/api/serviceFacade.ts
+++ b/src/app/api/serviceFacade.ts
@@ -122,3 +122,10 @@ export function getOrderDetails(poNumber: number) {
 }
 
 export const ORDER_DETAILS_QUERY_KEY = "fetchOrderDetails";
+
+/**
+ * Calls the /api/admin/maintenance route to toggle maintenance mode.
+ */
+export function adminToggleMaintenanceMode() {
+    return post("/api/admin/maintenance", {});
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,7 @@ import "./globals.css";
 import { auth } from "@/auth";
 import constants from "@/constants";
 import { maintenanceEnabled } from "@/db";
+import AdminIconLink from "@/components/AdminIconLink";
 import AccountAvatar from "@/components/AccountAvatar";
 import Cart from "@/components/Cart";
 import SignInCard from "@/components/SignInCard";
@@ -82,6 +83,9 @@ export default async function RootLayout({
                                             </Link>
                                         </Tooltip>
                                         <Box sx={{ flexGrow: 1 }} />
+                                        {session?.user?.admin && (
+                                            <AdminIconLink />
+                                        )}
                                         <Cart />
                                         <AccountAvatar />
                                     </Toolbar>

--- a/src/components/AdminIconLink.tsx
+++ b/src/components/AdminIconLink.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Link from "next/link";
+import { IconButton, Tooltip } from "@mui/material";
+import AdminIcon from "@mui/icons-material/AdminPanelSettingsOutlined";
+
+const AdminIconLink = () => {
+    return (
+        <Tooltip title="Admin Settings">
+            <IconButton component={Link} href="/admin" color="inherit">
+                <AdminIcon />
+            </IconButton>
+        </Tooltip>
+    );
+};
+export default AdminIconLink;

--- a/src/components/AdminSettings.tsx
+++ b/src/components/AdminSettings.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { adminToggleMaintenanceMode } from "@/app/api/serviceFacade";
+import withErrorAnnouncer, {
+    WithErrorAnnouncerProps,
+} from "@/components/common/error/withErrorAnnouncer";
+
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    Divider,
+    FormControl,
+    FormControlLabel,
+    FormHelperText,
+    Switch,
+    Typography,
+} from "@mui/material";
+import AdminIcon from "@mui/icons-material/AdminPanelSettingsOutlined";
+import { useMutation } from "@tanstack/react-query";
+
+const AdminSettings = ({
+    showErrorAnnouncer,
+    maintenance,
+}: WithErrorAnnouncerProps & {
+    maintenance: boolean;
+}) => {
+    const router = useRouter();
+
+    const { mutate: toggleMaintenanceMode, isPending } = useMutation({
+        mutationFn: adminToggleMaintenanceMode,
+        onSuccess: () => {
+            router.refresh();
+        },
+        onError: (error) => {
+            showErrorAnnouncer(
+                "There was an error toggling Maintenance Mode.",
+                error,
+            );
+        },
+    });
+
+    return (
+        <Card>
+            <CardHeader
+                avatar={<AdminIcon fontSize="large" />}
+                title={
+                    <Typography component="span" variant="h6">
+                        Admin Settings
+                    </Typography>
+                }
+            />
+            <Divider />
+            <CardContent>
+                <FormControl>
+                    <FormControlLabel
+                        label={`${maintenance ? "Disable" : "Enable"} Maintenance`}
+                        control={
+                            <Switch
+                                checked={maintenance}
+                                disabled={isPending}
+                                onChange={() => {
+                                    toggleMaintenanceMode();
+                                }}
+                            />
+                        }
+                    />
+                    <FormHelperText>
+                        Turn Maintenance Mode {maintenance ? "off" : "on"}
+                    </FormHelperText>
+                </FormControl>
+            </CardContent>
+        </Card>
+    );
+};
+
+export default withErrorAnnouncer(AdminSettings);

--- a/src/components/common/ContactSupport.tsx
+++ b/src/components/common/ContactSupport.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * A component that can be used to allow a user to contact support.
  */

--- a/src/components/common/error/ErrorHandler.tsx
+++ b/src/components/common/error/ErrorHandler.tsx
@@ -53,7 +53,7 @@ const BasicErrorCard = () => (
         }
         subheader={
             <Typography color="error">
-                This wasn{"'"}t supposed to happen. Please try again or contact
+                This {"wasn't"} supposed to happen. Please try again or contact
                 support!
             </Typography>
         }
@@ -64,7 +64,7 @@ const BasicErrorCard = () => (
     </ErrorCardTemplate>
 );
 
-const NotAuthorizedCard = () => (
+export const NotAuthorizedCard = () => (
     <ErrorCardTemplate
         avatar={<SupervisorAccountIcon color="primary" fontSize="large" />}
         title={

--- a/src/db.ts
+++ b/src/db.ts
@@ -171,6 +171,14 @@ export async function maintenanceEnabled() {
     }
 }
 
+export async function toggleMaintenanceMode() {
+    const { rows } = await db.query<{ enabled: boolean }>(
+        "UPDATE maintenance SET enabled = NOT enabled RETURNING enabled",
+    );
+
+    return rows?.[0]?.enabled ?? true;
+}
+
 /**
  * Adds the `transaction` to the database as a purchase order,
  * returning the `po_number`.


### PR DESCRIPTION
This PR will add an admin page with a switch control for turning maintenance mode on or off.

If the logged-in user is an admin, then an admin icon will display in the app bar, next to the cart icon, which will navigate to the new `/admin` page when clicked.

---

<img width="1024" height="350" alt="Admin Page with Maintenance Off" src="https://github.com/user-attachments/assets/78ad1ffa-0d45-42eb-90c7-f03cef015baa" />


---

<img width="1024" height="350" alt="Admin Page with Maintenance On" src="https://github.com/user-attachments/assets/9417a997-5c50-49af-829f-9189c606d4ac" />

---

<img width="1024" height="350" alt="Admin Page Dark Mode with Maintenance Off" src="https://github.com/user-attachments/assets/8557ee2d-be1d-499a-888c-af028de08dbf" />

---

<img width="1024" height="350" alt="Admin Page Dark Mode with Maintenance On" src="https://github.com/user-attachments/assets/c6b506a4-8a1e-4429-9556-74d7e2b7fd49" />

